### PR TITLE
Do away with Global, make config explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ $ go get github.com/cliffom/tokenex-go
 ## Usage
 
 ```go
-tokenex.Initialize(
+config := tokenex.NewConfig(
   "https://test-api.tokenex.com/TokenServices.svc/REST/",
   "YOUR_TOKENEX_ID",
   "YOUR_TOKENEX_API_KEY")
-token, tokenErr := tokenex.Tokenize("4242424242424242", tokenex.SIXTOKENFOUR)
-data, dataErr := tokenex.Detokenize(token.Token)
-validate, validateErr  := tokenex.Validate(token.Token)
-delete, deleteErr := tokenex.Delete(token.Token)
+token, tokenErr := tokenex.Tokenize("4242424242424242", tokenex.SIXTOKENFOUR, config)
+data, dataErr := tokenex.Detokenize(token.Token, config)
+validate, validateErr  := tokenex.Validate(token.Token, config)
+delete, deleteErr := tokenex.Delete(token.Token, config)
 ```
 
 ## License

--- a/config.go
+++ b/config.go
@@ -2,19 +2,19 @@ package tokenex
 
 import "log"
 
-type tokenexConfig struct {
+type Config struct {
 	baseUrl string
 	id      string
 	apiKey  string
 }
 
-func (c *tokenexConfig) init(baseUrl string, id string, apiKey string) {
+func (c *Config) init(baseUrl string, id string, apiKey string) {
 	c.baseUrl = baseUrl
 	c.id = id
 	c.apiKey = apiKey
 }
 
-func (c *tokenexConfig) validate() {
+func (c *Config) validate() {
 	if c.baseUrl == "" {
 		log.Fatalf("config.baseUrl not set")
 	} else if c.id == "" {

--- a/response.go
+++ b/response.go
@@ -34,8 +34,8 @@ type (
 	}
 )
 
-func (b *BaseResponse) result(v interface{}) error {
-	err := json.Unmarshal([]byte(b.request(b.Data)), &v)
+func (b *BaseResponse) result(v interface{}, config Config) error {
+	err := json.Unmarshal([]byte(b.request(b.Data, config)), &v)
 	errStr := ""
 	if err == nil {
 		switch v.(type) {
@@ -56,7 +56,7 @@ func (b *BaseResponse) result(v interface{}) error {
 	return err
 }
 
-func (b *BaseResponse) request(data map[string]interface{}) string {
+func (b *BaseResponse) request(data map[string]interface{}, config Config) string {
 	config.validate()
 	baseUrl := config.baseUrl
 	m := map[string]interface{}{

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -1,59 +1,59 @@
 package tokenex
 
-var config tokenexConfig
-
-func Initialize(baseUrl string, id string, apiKey string) {
+func NewConfig(baseUrl string, id string, apiKey string) Config {
+	var config Config
 	config.init(baseUrl, id, apiKey)
+	return config
 }
 
-func Tokenize(data string, tokenScheme int) (TokenResponse, error) {
+func Tokenize(data string, tokenScheme int, config Config) (TokenResponse, error) {
 	response := TokenResponse{}
 	response.Data = map[string]interface{}{
 		"Action":      "Tokenize",
 		"Data":        data,
 		"TokenScheme": tokenScheme,
 	}
-	err := response.result(&response)
+	err := response.result(&response, config)
 	return response, err
 }
 
-func TokenizeFromEncryptedValue(data string, tokenScheme int) (TokenResponse, error) {
+func TokenizeFromEncryptedValue(data string, tokenScheme int, config Config) (TokenResponse, error) {
 	response := TokenResponse{}
 	response.Data = map[string]interface{}{
 		"Action":       "TokenizeFromEncryptedValue",
 		"EcryptedData": data,
 		"TokenScheme":  tokenScheme,
 	}
-	err := response.result(&response)
+	err := response.result(&response, config)
 	return response, err
 }
 
-func Detokenize(token string) (ValueResponse, error) {
+func Detokenize(token string, config Config) (ValueResponse, error) {
 	response := ValueResponse{}
 	response.Data = map[string]interface{}{
 		"Action": "Detokenize",
 		"Token":  token,
 	}
-	err := response.result(&response)
+	err := response.result(&response, config)
 	return response, err
 }
 
-func Validate(token string) (ValidateResponse, error) {
+func Validate(token string, config Config) (ValidateResponse, error) {
 	response := ValidateResponse{}
 	response.Data = map[string]interface{}{
 		"Action": "ValidateToken",
 		"Token":  token,
 	}
-	err := response.result(&response)
+	err := response.result(&response, config)
 	return response, err
 }
 
-func Delete(token string) (DeleteResponse, error) {
+func Delete(token string, config Config) (DeleteResponse, error) {
 	response := DeleteResponse{}
 	response.Data = map[string]interface{}{
 		"Action": "DeleteToken",
 		"Token":  token,
 	}
-	err := response.result(&response)
+	err := response.result(&response, config)
 	return response, err
 }

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestTokenize(t *testing.T) {
-	Initialize(
+	teConfig := NewConfig(
 		os.Getenv("TOKENEX_BASE_URL"),
 		os.Getenv("TOKENEX_ID"),
 		os.Getenv("TOKENEX_API_KEY"))
 	ccNum := "4242424242424242"
-	token, tokenErr := Tokenize(ccNum, SIXTOKENFOUR)
-	data, dataErr := Detokenize(token.Token)
-	validate, validateErr := Validate(token.Token)
-	delete, deleteErr := Delete(token.Token)
+	token, tokenErr := Tokenize(ccNum, SIXTOKENFOUR, teConfig)
+	data, dataErr := Detokenize(token.Token, teConfig)
+	validate, validateErr := Validate(token.Token, teConfig)
+	delete, deleteErr := Delete(token.Token, teConfig)
 
 	if tokenErr != nil {
 		t.Errorf(string(tokenErr.Error()))

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestTokenize(t *testing.T) {
-	teConfig := NewConfig(
+	config := NewConfig(
 		os.Getenv("TOKENEX_BASE_URL"),
 		os.Getenv("TOKENEX_ID"),
 		os.Getenv("TOKENEX_API_KEY"))
 	ccNum := "4242424242424242"
-	token, tokenErr := Tokenize(ccNum, SIXTOKENFOUR, teConfig)
-	data, dataErr := Detokenize(token.Token, teConfig)
-	validate, validateErr := Validate(token.Token, teConfig)
-	delete, deleteErr := Delete(token.Token, teConfig)
+	token, tokenErr := Tokenize(ccNum, SIXTOKENFOUR, config)
+	data, dataErr := Detokenize(token.Token, config)
+	validate, validateErr := Validate(token.Token, config)
+	delete, deleteErr := Delete(token.Token, config)
 
 	if tokenErr != nil {
 		t.Errorf(string(tokenErr.Error()))


### PR DESCRIPTION
The original config implementation used a global variable. I wasn't a fan of doing that so instead the config should be created and passed.